### PR TITLE
refactor(git):  Fix of GetStatusForFiles

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,24 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"slices"
 	"strings"
 )
 
-// GetDiff returns the output of `git diff`.
-func GetDiff() (string, error) {
-	cmd := exec.Command("git", "diff")
-
-	out, err := cmd.CombinedOutput()
-
-	return string(out), err
-}
-
-// GetStatus returns the output of `git status --porcelain`.
-func GetStatus() (string, error) {
-	cmd := exec.Command("git", "status", "--porcelain")
-	out, err := cmd.CombinedOutput()
-	return string(out), err
-}
+// command is a variable that holds the function to execute a command.
+// It's implemented as a variable to allow for mocking in tests.
+var command = exec.Command
 
 // GetStatusForFiles returns the `git status --porcelain` output, but only for
 // the files specified in the input list.
@@ -32,56 +21,56 @@ func GetStatusForFiles(files []string) (string, error) {
 		return "", nil
 	}
 
-	// Create a set (using a map) for efficient O(1) lookups.
-	// This lets us quickly check if a file is one we care about.
-	filesToInclude := make(map[string]struct{})
-	for _, f := range files {
-		filesToInclude[f] = struct{}{}
-	}
-
 	// Get the status for the entire repository.
-	cmd := exec.Command("git", "status", "--porcelain")
+	args := []string{"status", "--porcelain", "--"}
+	args = append(args, files...)
+	cmd := command("git", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to run git status: %w", err)
 	}
-
-	var relevantLines []string
 	allLines := strings.Split(string(out), "\n")
-
-	// Iterate over each line of the status output and filter it.
-	for _, line := range allLines {
-		if len(line) < 4 {
-			continue // Skip empty or malformed lines
-		}
-
-		// The porcelain format is "XY filepath", so the path starts at index 3.
-		filePath := strings.TrimSpace(line[3:])
-
-		// A special case is a renamed file, e.g., "R  new-name -> old-name"
-		if strings.Contains(filePath, " -> ") {
-			parts := strings.Split(filePath, " -> ")
-			newName := parts[0]
-			oldName := parts[1]
-			// Include the line if either the old or new name is in our list.
-			if filesToInclude[newName] == struct{}{} || filesToInclude[oldName] == struct{}{} {
-				relevantLines = append(relevantLines, line)
-			}
-		} else {
-			// For all other cases, just check if the file path is in our set.
-			if filesToInclude[filePath] == struct{}{} {
-				relevantLines = append(relevantLines, line)
-			}
-		}
-	}
+	relevantLines := filterStatusLines(allLines, files)
 
 	// Join the filtered lines back into a single string.
 	return strings.Join(relevantLines, "\n"), nil
 }
 
+// filterStatusLines filters the raw output from `git status --porcelain`.
+// It returns only the lines relevant to the files.
+func filterStatusLines(allLines []string, files []string) []string {
+	var relevantLines []string
+	for _, line := range allLines {
+		if len(line) < 4 {
+			continue // Skip empty or malformed lines
+		}
+		// The porcelain format is "XY filepath", so the path starts at index 3.
+		filePath := strings.TrimSpace(line[3:])
+
+		// A special case is a renamed file, e.g., "R old-name -> new-name"
+		if strings.Contains(filePath, " -> ") {
+			parts := strings.Split(filePath, " -> ")
+			path1 := parts[0]
+			path2 := parts[1]
+			ok1 := slices.Contains(files, path1)
+			ok2 := slices.Contains(files, path2)
+			// Include the line if either the old or new name is in our list.
+			if ok1 || ok2 {
+				relevantLines = append(relevantLines, line)
+			}
+		} else {
+			// For all other cases, check if the file path is in our set.
+			if ok := slices.Contains(files, filePath); ok {
+				relevantLines = append(relevantLines, line)
+			}
+		}
+	}
+	return relevantLines
+}
+
 // GetChangedFiles returns a list of changed (modified, new, etc.) files.
 func GetChangedFiles() ([]string, error) {
-	out, err := exec.Command("git", "status", "--porcelain").Output()
+	out, err := command("git", "status", "--porcelain").Output()
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +104,7 @@ func GetChangesForFiles(files []string) (string, error) {
 	// Construct the arguments: git diff HEAD -- <file1> <file2>...
 	args := append([]string{"diff", "HEAD", "--"}, clean...)
 
-	cmd := exec.Command("git", args...)
+	cmd := command("git", args...)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
@@ -138,7 +127,7 @@ func Commit(files []string, message string) error {
 
 	// First, stage the specific files
 	addArgs := append([]string{"add", "--"}, files...)
-	if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
+	if out, err := command("git", addArgs...).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to stage files: %w\n%s", err, string(out))
 	}
 
@@ -146,7 +135,7 @@ func Commit(files []string, message string) error {
 	// Note: We don't use -a here. We commit what we just added.
 	commitArgs := append([]string{"commit", "-m", message, "--"})
 	commitArgs = append(commitArgs, files...)
-	if out, err := exec.Command("git", commitArgs...).CombinedOutput(); err != nil {
+	if out, err := command("git", commitArgs...).CombinedOutput(); err != nil {
 		// Check if the error is "nothing to commit" and if so, return nil.
 		// This can happen if the files added had no actual changes.
 		if strings.Contains(string(out), "nothing to commit") {
@@ -161,7 +150,7 @@ func Commit(files []string, message string) error {
 // Push pushes the current branch to the remote repository.
 // This simplified version returns Git's helpful error messages directly.
 func Push() error {
-	cmd := exec.Command("git", "push")
+	cmd := command("git", "push")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git push failed: %s", string(out))

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,392 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestHelperProcess isn't a real test. It's a helper process that acts as a fake command.
+// It's executed by the *exec.Cmd created in the mock command functions.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	fmt.Fprint(os.Stdout, os.Getenv("STDOUT"))
+	fmt.Fprint(os.Stderr, os.Getenv("STDERR"))
+
+	i, err := strconv.Atoi(os.Getenv("EXIT_CODE"))
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(i)
+}
+
+// newMockExecCommand returns a function that mocks exec.Command for a single command call.
+func newMockExecCommand(t *testing.T, expectedArgs []string, stdout, stderr string, exitCode int) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		fullArgs := append([]string{name}, args...)
+		if !reflect.DeepEqual(fullArgs, expectedArgs) {
+			t.Errorf("expected command %v, got %v", expectedArgs, fullArgs)
+		}
+
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", name)
+		cmd.Args = append(cmd.Args, args...)
+		cmd.Env = []string{
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("STDOUT=%s", stdout),
+			fmt.Sprintf("STDERR=%s", stderr),
+			fmt.Sprintf("EXIT_CODE=%d", exitCode),
+		}
+		return cmd
+	}
+}
+
+type mockCall struct {
+	expectedArgs []string
+	stdout       string
+	stderr       string
+	exitCode     int
+}
+
+// newMultiMockExecCommand returns a function that mocks exec.Command for a sequence of calls.
+func newMultiMockExecCommand(t *testing.T, calls []mockCall) func(string, ...string) *exec.Cmd {
+	callNum := 0
+	return func(name string, args ...string) *exec.Cmd {
+		if callNum >= len(calls) {
+			t.Fatalf("unexpected command call: %s %v", name, args)
+		}
+		c := calls[callNum]
+		callNum++
+
+		fullArgs := append([]string{name}, args...)
+		if !reflect.DeepEqual(fullArgs, c.expectedArgs) {
+			t.Errorf("call %d: expected command %v, got %v", callNum-1, c.expectedArgs, fullArgs)
+		}
+
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", name)
+		cmd.Args = append(cmd.Args, args...)
+		cmd.Env = []string{
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("STDOUT=%s", c.stdout),
+			fmt.Sprintf("STDERR=%s", c.stderr),
+			fmt.Sprintf("EXIT_CODE=%d", c.exitCode),
+		}
+		return cmd
+	}
+}
+
+func TestGetStatusForFiles(t *testing.T) {
+	testCases := []struct {
+		name            string
+		files           []string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expected        string
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:     "no files",
+			files:    []string{},
+			expected: "",
+		},
+		{
+			name:  "files with status",
+			files: []string{"file1.go", "file2.go"},
+			stdout: " M file1.go\n" +
+				" A file3.go\n" +
+				" D file4.go\n" +
+				"?? file2.go",
+			expected:        " M file1.go\n?? file2.go",
+			expectedCmdArgs: []string{"git", "status", "--porcelain", "--", "file1.go", "file2.go"},
+		},
+		{
+			name:            "renamed file",
+			files:           []string{"new-name.go"},
+			stdout:          "R  new-name.go -> old-name.go",
+			expected:        "R  new-name.go -> old-name.go",
+			expectedCmdArgs: []string{"git", "status", "--porcelain", "--", "new-name.go"},
+		},
+		{
+			name:            "git status error",
+			files:           []string{"file1.go"},
+			stdout:          "git error", // CombinedOutput puts stderr into the output buffer
+			exitCode:        1,
+			expectedErr:     "failed to run git status",
+			expectedCmdArgs: []string{"git", "status", "--porcelain", "--", "file1.go"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedCmdArgs != nil {
+				command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+				defer func() { command = exec.Command }()
+			}
+
+			result, err := GetStatusForFiles(tc.files)
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+			if result != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetChangedFiles(t *testing.T) {
+	testCases := []struct {
+		name            string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expected        []string
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:            "files with status",
+			stdout:          " M file1.go\n A file2.go",
+			expected:        []string{"file1.go", "file2.go"},
+			expectedCmdArgs: []string{"git", "status", "--porcelain"},
+		},
+		{
+			name:            "no changed files",
+			stdout:          "",
+			expected:        nil,
+			expectedCmdArgs: []string{"git", "status", "--porcelain"},
+		},
+		{
+			name:            "git status error",
+			stderr:          "git error",
+			exitCode:        1,
+			expectedErr:     "exit status 1",
+			expectedCmdArgs: []string{"git", "status", "--porcelain"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+			defer func() { command = exec.Command }()
+
+			result, err := GetChangedFiles()
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("expected '%v', got '%v'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetChangesForFiles(t *testing.T) {
+	testCases := []struct {
+		name            string
+		files           []string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expected        string
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:     "no files",
+			files:    []string{},
+			expected: "",
+		},
+		{
+			name:  "files with changes",
+			files: []string{"file1.go", "file2.go"},
+			stdout: "diff --git a/file1.go b/file1.go\n" +
+				"--- a/file1.go\n" +
+				"+++ b/file1.go\n" +
+				"@@ -1,1 +1,1 @@\n" +
+				"-hello\n" +
+				"+world\n",
+			expected: "diff --git a/file1.go b/file1.go\n" +
+				"--- a/file1.go\n" +
+				"+++ b/file1.go\n" +
+				"@@ -1,1 +1,1 @@\n" +
+				"-hello\n" +
+				"+world\n",
+			expectedCmdArgs: []string{"git", "diff", "HEAD", "--", "file1.go", "file2.go"},
+		},
+		{
+			name:            "git diff error",
+			files:           []string{"file1.go"},
+			stderr:          "git error",
+			exitCode:        1,
+			expectedErr:     "git diff failed: exit status 1\ngit error",
+			expectedCmdArgs: []string{"git", "diff", "HEAD", "--", "file1.go"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedCmdArgs != nil {
+				command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+				defer func() { command = exec.Command }()
+			}
+
+			result, err := GetChangesForFiles(tc.files)
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+			if result != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestCommit(t *testing.T) {
+	testCases := []struct {
+		name        string
+		files       []string
+		message     string
+		calls       []mockCall
+		expectedErr string
+	}{
+		{
+			name:        "no files",
+			files:       []string{},
+			message:     "test commit",
+			expectedErr: "no files provided to commit",
+		},
+		{
+			name:    "successful commit",
+			files:   []string{"file1.go"},
+			message: "test commit",
+			calls: []mockCall{
+				{expectedArgs: []string{"git", "add", "--", "file1.go"}},
+				{expectedArgs: []string{"git", "commit", "-m", "test commit", "--", "file1.go"}, stdout: "[main 12345] test commit"},
+			},
+		},
+		{
+			name:    "git add fails",
+			files:   []string{"file1.go"},
+			message: "test commit",
+			calls: []mockCall{
+				{expectedArgs: []string{"git", "add", "--", "file1.go"}, stdout: "error adding", exitCode: 1},
+			},
+			expectedErr: "failed to stage files: exit status 1\nerror adding",
+		},
+		{
+			name:    "git commit fails",
+			files:   []string{"file1.go"},
+			message: "test commit",
+			calls: []mockCall{
+				{expectedArgs: []string{"git", "add", "--", "file1.go"}},
+				{expectedArgs: []string{"git", "commit", "-m", "test commit", "--", "file1.go"}, stdout: "error committing", exitCode: 1},
+			},
+			expectedErr: "git commit failed: exit status 1\nerror committing",
+		},
+		{
+			name:    "nothing to commit",
+			files:   []string{"file1.go"},
+			message: "test commit",
+			calls: []mockCall{
+				{expectedArgs: []string{"git", "add", "--", "file1.go"}},
+				{expectedArgs: []string{"git", "commit", "-m", "test commit", "--", "file1.go"}, stdout: "nothing to commit, working tree clean", exitCode: 1},
+			},
+			expectedErr: "", // Should not return an error
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.calls != nil {
+				command = newMultiMockExecCommand(t, tc.calls)
+				defer func() { command = exec.Command }()
+			}
+
+			err := Commit(tc.files, tc.message)
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestPush(t *testing.T) {
+	testCases := []struct {
+		name            string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:            "successful push",
+			stdout:          "Everything up-to-date",
+			expectedCmdArgs: []string{"git", "push"},
+		},
+		{
+			name:            "push fails",
+			stdout:          "fatal: No configured push destination",
+			exitCode:        128,
+			expectedErr:     "git push failed: fatal: No configured push destination",
+			expectedCmdArgs: []string{"git", "push"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+			defer func() { command = exec.Command }()
+
+			err := Push()
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+		})
+	}
+}

--- a/internal/git/gitroot_test.go
+++ b/internal/git/gitroot_test.go
@@ -1,0 +1,55 @@
+package git
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestGetGitRoot(t *testing.T) {
+	testCases := []struct {
+		name            string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expected        string
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:            "successful",
+			stdout:          "/path/to/repo\n",
+			expected:        "/path/to/repo",
+			expectedCmdArgs: []string{"git", "rev-parse", "--show-toplevel"},
+		},
+		{
+			name:            "git error",
+			stderr:          "fatal: not a git repository",
+			exitCode:        128,
+			expectedErr:     "exit status 128",
+			expectedCmdArgs: []string{"git", "rev-parse", "--show-toplevel"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+			defer func() { command = exec.Command }()
+
+			result, err := GetGitRoot()
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+			if result != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix status of filing including staged files not selected by user and improve test of git package.

- Introduce `command` variable to allow mocking `exec.Command` calls for testing.
- Update `git` package functions to utilize the mockable `command` variable.
- Add comprehensive unit tests for `GetStatusForFiles`, `GetChangedFiles`, `GetChangesForFiles`, `Commit`, and `Push`.
- Add unit tests for `GetGitRoot`.
- Refactor `GetStatusForFiles` by introducing `filterStatusLines` for clearer logic.
- Remove unused `GetDiff` and `GetStatus` functions.


review @huseynovvusal 