### PR TITLE
feat(suggest): improve commit message editor configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The project supports multiple AI backends (OpenAI, Google Gemini via genai, and 
 
 - **AI-generated commit message suggestions** based on repo diffs
 - _Interactive TUI_ to select files and review suggestions 🖱️
+- **Edit & Regenerate**: Tweak suggestions in-place or regenerate them with a keystroke 🔄
 - Pluggable AI backends: OpenAI, Google GenAI, Ollama (local)
 - Small single-binary distribution (Go) ⚙️
 
@@ -78,6 +79,7 @@ gitai suggest --provider=gemini_cli
 - list changed files (using `git status --porcelain`)
 - allow selecting files via an interactive file selector
 - fetch diffs for selected files and call the configured AI backend to produce suggestions
+- allow editing the suggestion (press `e`) or regenerating it (press `r`)
 
 See `internal/tui/suggest` for the implementation of the flow.
 
@@ -106,6 +108,10 @@ Supported keys
 - ollama.path: Path to the Ollama binary when provider=ollama
   - Env: OLLAMA_API_PATH
   - Config key: ollama.path
+- suggest.editor: Which editor to use for editing commit messages. Options: external, internal
+  - Flag: --editor or -e
+  - Config key: suggest.editor
+  - Default: external (uses $EDITOR/$VISUAL)
 
 Config files
 - Base name: gitai (no extension in code). Viper will load any supported format found (e.g., gitai.yaml, gitai.yml, gitai.json, etc.).
@@ -125,6 +131,9 @@ ai:
 # Only needed if you use provider=ollama
 ollama:
   path: "/usr/local/bin/ollama"
+
+suggest:
+  editor: internal # Use the built-in TUI editor
 ```
 Example gitai.json
 ```json
@@ -135,6 +144,9 @@ Example gitai.json
   },
   "ollama": {
     "path": "/usr/local/bin/ollama"
+  },
+  "suggest": {
+    "editor": "internal"
   }
 }
 ```
@@ -145,6 +157,8 @@ Examples
 - Use OpenAI with env var:
   - ```export GITAI_AI_API_KEY="sk-..."```
   - ```gitai suggest --provider=gpt```
+- Use internal editor:
+  - `gitai suggest --editor=internal`
 - Use config file only:
   - Create the gitai file in any of the supported search paths
   - `gitai suggest`

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Supported keys
 - ollama.path: Path to the Ollama binary when provider=ollama
   - Env: OLLAMA_API_PATH
   - Config key: ollama.path
-- suggest.editor: Which editor to use for editing commit messages. Options: external, internal
+- suggest.editor: Which editor to use for editing commit messages. Options: system, internal, or a command (e.g. "nano", "code -w")
   - Flag: --editor or -e
   - Config key: suggest.editor
-  - Default: external (uses $EDITOR/$VISUAL)
+  - Default: system (uses $EDITOR/$VISUAL)
 
 Config files
 - Base name: gitai (no extension in code). Viper will load any supported format found (e.g., gitai.yaml, gitai.yml, gitai.json, etc.).
@@ -133,7 +133,7 @@ ollama:
   path: "/usr/local/bin/ollama"
 
 suggest:
-  editor: internal # Use the built-in TUI editor
+  editor: builtin # Use the built-in TUI editor
 ```
 Example gitai.json
 ```json
@@ -146,7 +146,7 @@ Example gitai.json
     "path": "/usr/local/bin/ollama"
   },
   "suggest": {
-    "editor": "internal"
+    "editor": "builtin"
   }
 }
 ```
@@ -157,8 +157,10 @@ Examples
 - Use OpenAI with env var:
   - ```export GITAI_AI_API_KEY="sk-..."```
   - ```gitai suggest --provider=gpt```
-- Use internal editor:
-  - `gitai suggest --editor=internal`
+- Use builtin editor:
+  - `gitai suggest --editor=builtin`
+- Use custom editor command:
+  - `gitai suggest --editor="code -w"`
 - Use config file only:
   - Create the gitai file in any of the supported search paths
   - `gitai suggest`

--- a/cmd/suggest.go
+++ b/cmd/suggest.go
@@ -31,7 +31,7 @@ var suggestCmd = &cobra.Command{
 func init() {
 	suggestCmd.Flags().StringP("provider", "p", "", "AI provider to use (gpt|gemini|ollama|geminicli). If empty, uses env or config or default")
 	suggestCmd.Flags().StringP("api_key", "k", "", "Optional API key to provide to AI provider")
-	suggestCmd.Flags().StringP("editor", "e", "external", "Editor to use for commit messages (external|internal)")
+	suggestCmd.Flags().StringP("editor", "e", "system", "Editor to use for commit messages (builtin, system, or command)")
 	_ = viper.BindPFlag("ai.provider", suggestCmd.Flags().Lookup("provider"))
 	_ = viper.BindPFlag("ai.api_key", suggestCmd.Flags().Lookup("api_key"))
 	_ = viper.BindPFlag("suggest.editor", suggestCmd.Flags().Lookup("editor"))

--- a/cmd/suggest.go
+++ b/cmd/suggest.go
@@ -23,14 +23,17 @@ var suggestCmd = &cobra.Command{
 			return
 		}
 
-		suggest.RunSuggestFlow(rootCtx, provider)
+		editorMode := viper.GetString("suggest.editor")
+		suggest.RunSuggestFlow(rootCtx, provider, editorMode)
 	},
 }
 
 func init() {
 	suggestCmd.Flags().StringP("provider", "p", "", "AI provider to use (gpt|gemini|ollama|geminicli). If empty, uses env or config or default")
 	suggestCmd.Flags().StringP("api_key", "k", "", "Optional API key to provide to AI provider")
+	suggestCmd.Flags().StringP("editor", "e", "external", "Editor to use for commit messages (external|internal)")
 	_ = viper.BindPFlag("ai.provider", suggestCmd.Flags().Lookup("provider"))
-	_ = viper.BindPFlag("ai.api_key", suggestCmd.Flags().Lookup("provider"))
+	_ = viper.BindPFlag("ai.api_key", suggestCmd.Flags().Lookup("api_key"))
+	_ = viper.BindPFlag("suggest.editor", suggestCmd.Flags().Lookup("editor"))
 	rootCmd.AddCommand(suggestCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	cloud.google.com/go v0.116.0 // indirect
 	cloud.google.com/go/auth v0.9.3 // indirect
 	cloud.google.com/go/compute/metadata v0.5.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/auth v0.9.3/go.mod h1:7z6VY+7h3KUdRov5F1i8NDP5ZzWKYmEPO842Bg
 cloud.google.com/go/compute/metadata v0.5.0 h1:Zr0eK8JbFv6+Wi4ilXAR8FJ3wyNdpxHKJNPos6LTZOY=
 cloud.google.com/go/compute/metadata v0.5.0/go.mod h1:aHnloV2TPI38yx4s9+wAZhHykWvVCfu7hQbF+9CWoiY=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,24 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"slices"
 	"strings"
 )
 
-// GetDiff returns the output of `git diff`.
-func GetDiff() (string, error) {
-	cmd := exec.Command("git", "diff")
-
-	out, err := cmd.CombinedOutput()
-
-	return string(out), err
-}
-
-// GetStatus returns the output of `git status --porcelain`.
-func GetStatus() (string, error) {
-	cmd := exec.Command("git", "status", "--porcelain")
-	out, err := cmd.CombinedOutput()
-	return string(out), err
-}
+// command is a variable that holds the function to execute a command.
+// It's implemented as a variable to allow for mocking in tests.
+var command = exec.Command
 
 // GetStatusForFiles returns the `git status --porcelain` output, but only for
 // the files specified in the input list.
@@ -32,56 +21,56 @@ func GetStatusForFiles(files []string) (string, error) {
 		return "", nil
 	}
 
-	// Create a set (using a map) for efficient O(1) lookups.
-	// This lets us quickly check if a file is one we care about.
-	filesToInclude := make(map[string]struct{})
-	for _, f := range files {
-		filesToInclude[f] = struct{}{}
-	}
-
 	// Get the status for the entire repository.
-	cmd := exec.Command("git", "status", "--porcelain")
+	args := []string{"status", "--porcelain", "--"}
+	args = append(args, files...)
+	cmd := command("git", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to run git status: %w", err)
 	}
-
-	var relevantLines []string
 	allLines := strings.Split(string(out), "\n")
-
-	// Iterate over each line of the status output and filter it.
-	for _, line := range allLines {
-		if len(line) < 4 {
-			continue // Skip empty or malformed lines
-		}
-
-		// The porcelain format is "XY filepath", so the path starts at index 3.
-		filePath := strings.TrimSpace(line[3:])
-
-		// A special case is a renamed file, e.g., "R  new-name -> old-name"
-		if strings.Contains(filePath, " -> ") {
-			parts := strings.Split(filePath, " -> ")
-			newName := parts[0]
-			oldName := parts[1]
-			// Include the line if either the old or new name is in our list.
-			if filesToInclude[newName] == struct{}{} || filesToInclude[oldName] == struct{}{} {
-				relevantLines = append(relevantLines, line)
-			}
-		} else {
-			// For all other cases, just check if the file path is in our set.
-			if filesToInclude[filePath] == struct{}{} {
-				relevantLines = append(relevantLines, line)
-			}
-		}
-	}
+	relevantLines := filterStatusLines(allLines, files)
 
 	// Join the filtered lines back into a single string.
 	return strings.Join(relevantLines, "\n"), nil
 }
 
+// filterStatusLines filters the raw output from `git status --porcelain`.
+// It returns only the lines relevant to the files.
+func filterStatusLines(allLines []string, files []string) []string {
+	var relevantLines []string
+	for _, line := range allLines {
+		if len(line) < 4 {
+			continue // Skip empty or malformed lines
+		}
+		// The porcelain format is "XY filepath", so the path starts at index 3.
+		filePath := strings.TrimSpace(line[3:])
+
+		// A special case is a renamed file, e.g., "R old-name -> new-name"
+		if strings.Contains(filePath, " -> ") {
+			parts := strings.Split(filePath, " -> ")
+			path1 := parts[0]
+			path2 := parts[1]
+			ok1 := slices.Contains(files, path1)
+			ok2 := slices.Contains(files, path2)
+			// Include the line if either the old or new name is in our list.
+			if ok1 || ok2 {
+				relevantLines = append(relevantLines, line)
+			}
+		} else {
+			// For all other cases, check if the file path is in our set.
+			if ok := slices.Contains(files, filePath); ok {
+				relevantLines = append(relevantLines, line)
+			}
+		}
+	}
+	return relevantLines
+}
+
 // GetChangedFiles returns a list of changed (modified, new, etc.) files.
 func GetChangedFiles() ([]string, error) {
-	out, err := exec.Command("git", "status", "--porcelain").Output()
+	out, err := command("git", "status", "--porcelain").Output()
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +104,7 @@ func GetChangesForFiles(files []string) (string, error) {
 	// Construct the arguments: git diff HEAD -- <file1> <file2>...
 	args := append([]string{"diff", "HEAD", "--"}, clean...)
 
-	cmd := exec.Command("git", args...)
+	cmd := command("git", args...)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
@@ -138,7 +127,7 @@ func Commit(files []string, message string) error {
 
 	// First, stage the specific files
 	addArgs := append([]string{"add", "--"}, files...)
-	if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
+	if out, err := command("git", addArgs...).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to stage files: %w\n%s", err, string(out))
 	}
 
@@ -146,7 +135,7 @@ func Commit(files []string, message string) error {
 	// Note: We don't use -a here. We commit what we just added.
 	commitArgs := append([]string{"commit", "-m", message, "--"})
 	commitArgs = append(commitArgs, files...)
-	if out, err := exec.Command("git", commitArgs...).CombinedOutput(); err != nil {
+	if out, err := command("git", commitArgs...).CombinedOutput(); err != nil {
 		// Check if the error is "nothing to commit" and if so, return nil.
 		// This can happen if the files added had no actual changes.
 		if strings.Contains(string(out), "nothing to commit") {
@@ -161,7 +150,7 @@ func Commit(files []string, message string) error {
 // Push pushes the current branch to the remote repository.
 // This simplified version returns Git's helpful error messages directly.
 func Push() error {
-	cmd := exec.Command("git", "push")
+	cmd := command("git", "push")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git push failed: %s", string(out))

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,392 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestHelperProcess isn't a real test. It's a helper process that acts as a fake command.
+// It's executed by the *exec.Cmd created in the mock command functions.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	fmt.Fprint(os.Stdout, os.Getenv("STDOUT"))
+	fmt.Fprint(os.Stderr, os.Getenv("STDERR"))
+
+	i, err := strconv.Atoi(os.Getenv("EXIT_CODE"))
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(i)
+}
+
+// newMockExecCommand returns a function that mocks exec.Command for a single command call.
+func newMockExecCommand(t *testing.T, expectedArgs []string, stdout, stderr string, exitCode int) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		fullArgs := append([]string{name}, args...)
+		if !reflect.DeepEqual(fullArgs, expectedArgs) {
+			t.Errorf("expected command %v, got %v", expectedArgs, fullArgs)
+		}
+
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", name)
+		cmd.Args = append(cmd.Args, args...)
+		cmd.Env = []string{
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("STDOUT=%s", stdout),
+			fmt.Sprintf("STDERR=%s", stderr),
+			fmt.Sprintf("EXIT_CODE=%d", exitCode),
+		}
+		return cmd
+	}
+}
+
+type mockCall struct {
+	expectedArgs []string
+	stdout       string
+	stderr       string
+	exitCode     int
+}
+
+// newMultiMockExecCommand returns a function that mocks exec.Command for a sequence of calls.
+func newMultiMockExecCommand(t *testing.T, calls []mockCall) func(string, ...string) *exec.Cmd {
+	callNum := 0
+	return func(name string, args ...string) *exec.Cmd {
+		if callNum >= len(calls) {
+			t.Fatalf("unexpected command call: %s %v", name, args)
+		}
+		c := calls[callNum]
+		callNum++
+
+		fullArgs := append([]string{name}, args...)
+		if !reflect.DeepEqual(fullArgs, c.expectedArgs) {
+			t.Errorf("call %d: expected command %v, got %v", callNum-1, c.expectedArgs, fullArgs)
+		}
+
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", name)
+		cmd.Args = append(cmd.Args, args...)
+		cmd.Env = []string{
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("STDOUT=%s", c.stdout),
+			fmt.Sprintf("STDERR=%s", c.stderr),
+			fmt.Sprintf("EXIT_CODE=%d", c.exitCode),
+		}
+		return cmd
+	}
+}
+
+func TestGetStatusForFiles(t *testing.T) {
+	testCases := []struct {
+		name            string
+		files           []string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expected        string
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:     "no files",
+			files:    []string{},
+			expected: "",
+		},
+		{
+			name:  "files with status",
+			files: []string{"file1.go", "file2.go"},
+			stdout: " M file1.go\n" +
+				" A file3.go\n" +
+				" D file4.go\n" +
+				"?? file2.go",
+			expected:        " M file1.go\n?? file2.go",
+			expectedCmdArgs: []string{"git", "status", "--porcelain", "--", "file1.go", "file2.go"},
+		},
+		{
+			name:            "renamed file",
+			files:           []string{"new-name.go"},
+			stdout:          "R  new-name.go -> old-name.go",
+			expected:        "R  new-name.go -> old-name.go",
+			expectedCmdArgs: []string{"git", "status", "--porcelain", "--", "new-name.go"},
+		},
+		{
+			name:            "git status error",
+			files:           []string{"file1.go"},
+			stdout:          "git error", // CombinedOutput puts stderr into the output buffer
+			exitCode:        1,
+			expectedErr:     "failed to run git status",
+			expectedCmdArgs: []string{"git", "status", "--porcelain", "--", "file1.go"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedCmdArgs != nil {
+				command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+				defer func() { command = exec.Command }()
+			}
+
+			result, err := GetStatusForFiles(tc.files)
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+			if result != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetChangedFiles(t *testing.T) {
+	testCases := []struct {
+		name            string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expected        []string
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:            "files with status",
+			stdout:          " M file1.go\n A file2.go",
+			expected:        []string{"file1.go", "file2.go"},
+			expectedCmdArgs: []string{"git", "status", "--porcelain"},
+		},
+		{
+			name:            "no changed files",
+			stdout:          "",
+			expected:        nil,
+			expectedCmdArgs: []string{"git", "status", "--porcelain"},
+		},
+		{
+			name:            "git status error",
+			stderr:          "git error",
+			exitCode:        1,
+			expectedErr:     "exit status 1",
+			expectedCmdArgs: []string{"git", "status", "--porcelain"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+			defer func() { command = exec.Command }()
+
+			result, err := GetChangedFiles()
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("expected '%v', got '%v'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetChangesForFiles(t *testing.T) {
+	testCases := []struct {
+		name            string
+		files           []string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expected        string
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:     "no files",
+			files:    []string{},
+			expected: "",
+		},
+		{
+			name:  "files with changes",
+			files: []string{"file1.go", "file2.go"},
+			stdout: "diff --git a/file1.go b/file1.go\n" +
+				"--- a/file1.go\n" +
+				"+++ b/file1.go\n" +
+				"@@ -1,1 +1,1 @@\n" +
+				"-hello\n" +
+				"+world\n",
+			expected: "diff --git a/file1.go b/file1.go\n" +
+				"--- a/file1.go\n" +
+				"+++ b/file1.go\n" +
+				"@@ -1,1 +1,1 @@\n" +
+				"-hello\n" +
+				"+world\n",
+			expectedCmdArgs: []string{"git", "diff", "HEAD", "--", "file1.go", "file2.go"},
+		},
+		{
+			name:            "git diff error",
+			files:           []string{"file1.go"},
+			stderr:          "git error",
+			exitCode:        1,
+			expectedErr:     "git diff failed: exit status 1\ngit error",
+			expectedCmdArgs: []string{"git", "diff", "HEAD", "--", "file1.go"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectedCmdArgs != nil {
+				command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+				defer func() { command = exec.Command }()
+			}
+
+			result, err := GetChangesForFiles(tc.files)
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+			if result != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestCommit(t *testing.T) {
+	testCases := []struct {
+		name        string
+		files       []string
+		message     string
+		calls       []mockCall
+		expectedErr string
+	}{
+		{
+			name:        "no files",
+			files:       []string{},
+			message:     "test commit",
+			expectedErr: "no files provided to commit",
+		},
+		{
+			name:    "successful commit",
+			files:   []string{"file1.go"},
+			message: "test commit",
+			calls: []mockCall{
+				{expectedArgs: []string{"git", "add", "--", "file1.go"}},
+				{expectedArgs: []string{"git", "commit", "-m", "test commit", "--", "file1.go"}, stdout: "[main 12345] test commit"},
+			},
+		},
+		{
+			name:    "git add fails",
+			files:   []string{"file1.go"},
+			message: "test commit",
+			calls: []mockCall{
+				{expectedArgs: []string{"git", "add", "--", "file1.go"}, stdout: "error adding", exitCode: 1},
+			},
+			expectedErr: "failed to stage files: exit status 1\nerror adding",
+		},
+		{
+			name:    "git commit fails",
+			files:   []string{"file1.go"},
+			message: "test commit",
+			calls: []mockCall{
+				{expectedArgs: []string{"git", "add", "--", "file1.go"}},
+				{expectedArgs: []string{"git", "commit", "-m", "test commit", "--", "file1.go"}, stdout: "error committing", exitCode: 1},
+			},
+			expectedErr: "git commit failed: exit status 1\nerror committing",
+		},
+		{
+			name:    "nothing to commit",
+			files:   []string{"file1.go"},
+			message: "test commit",
+			calls: []mockCall{
+				{expectedArgs: []string{"git", "add", "--", "file1.go"}},
+				{expectedArgs: []string{"git", "commit", "-m", "test commit", "--", "file1.go"}, stdout: "nothing to commit, working tree clean", exitCode: 1},
+			},
+			expectedErr: "", // Should not return an error
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.calls != nil {
+				command = newMultiMockExecCommand(t, tc.calls)
+				defer func() { command = exec.Command }()
+			}
+
+			err := Commit(tc.files, tc.message)
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestPush(t *testing.T) {
+	testCases := []struct {
+		name            string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:            "successful push",
+			stdout:          "Everything up-to-date",
+			expectedCmdArgs: []string{"git", "push"},
+		},
+		{
+			name:            "push fails",
+			stdout:          "fatal: No configured push destination",
+			exitCode:        128,
+			expectedErr:     "git push failed: fatal: No configured push destination",
+			expectedCmdArgs: []string{"git", "push"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+			defer func() { command = exec.Command }()
+
+			err := Push()
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+		})
+	}
+}

--- a/internal/git/gitroot_test.go
+++ b/internal/git/gitroot_test.go
@@ -1,0 +1,55 @@
+package git
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestGetGitRoot(t *testing.T) {
+	testCases := []struct {
+		name            string
+		stdout          string
+		stderr          string
+		exitCode        int
+		expected        string
+		expectedErr     string
+		expectedCmdArgs []string
+	}{
+		{
+			name:            "successful",
+			stdout:          "/path/to/repo\n",
+			expected:        "/path/to/repo",
+			expectedCmdArgs: []string{"git", "rev-parse", "--show-toplevel"},
+		},
+		{
+			name:            "git error",
+			stderr:          "fatal: not a git repository",
+			exitCode:        128,
+			expectedErr:     "exit status 128",
+			expectedCmdArgs: []string{"git", "rev-parse", "--show-toplevel"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+			defer func() { command = exec.Command }()
+
+			result, err := GetGitRoot()
+
+			if err != nil && tc.expectedErr == "" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("expected error but got none")
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+			}
+			if result != tc.expected {
+				t.Errorf("expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}

--- a/internal/tui/suggest/ai_message.go
+++ b/internal/tui/suggest/ai_message.go
@@ -2,9 +2,13 @@ package suggest
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"huseynovvusal/gitai/internal/ai"
@@ -35,6 +39,11 @@ type commitSecurityWarningMsg struct {
 	status string
 }
 
+type editorFinishedMsg struct {
+	err      error
+	filename string
+}
+
 type State int
 
 const (
@@ -46,6 +55,7 @@ const (
 	StatePushed                       // push succeeded; show success and exit option
 	StateError                        // show error (store message)
 	StateSecurityWarning              // warn and prompt the user for confirmation regarding safety reasons of the code being committed
+	StateEditing                      // Internal editor active
 )
 
 type AIMessageModel struct {
@@ -59,12 +69,20 @@ type AIMessageModel struct {
 	savedDiff     string
 	savedStatus   string
 	ctx           context.Context
+	editorMode    string
+	textArea      textarea.Model
 }
 
-func NewAIMessageModel(ctx context.Context, files []string, provider ai.Provider) AIMessageModel {
+func NewAIMessageModel(ctx context.Context, files []string, provider ai.Provider, editorMode string) AIMessageModel {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = shared.CursorStyle
+
+	ta := textarea.New()
+	ta.Placeholder = "Enter commit message..."
+	ta.ShowLineNumbers = false
+	ta.SetWidth(80)
+	ta.SetHeight(10)
 
 	return AIMessageModel{
 		files:         files,
@@ -75,6 +93,8 @@ func NewAIMessageModel(ctx context.Context, files []string, provider ai.Provider
 		cancel:        false,
 		ctx:           ctx,
 		provider:      provider,
+		editorMode:    editorMode,
+		textArea:      ta,
 	}
 }
 
@@ -130,6 +150,41 @@ func runPushAsync() tea.Cmd {
 	}
 }
 
+func openEditor(content string) tea.Cmd {
+	f, err := os.CreateTemp("", "gitai-commit-msg-*.txt")
+	if err != nil {
+		return func() tea.Msg { return aiErrorMsg{err: err} }
+	}
+
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return func() tea.Msg { return aiErrorMsg{err: err} }
+	}
+	f.Close()
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = os.Getenv("VISUAL")
+	}
+	if editor == "" {
+		editor = "vim"
+	}
+
+	parts := strings.Fields(editor)
+	var c *exec.Cmd
+	if len(parts) > 0 {
+		args := append(parts[1:], f.Name())
+		c = exec.Command(parts[0], args...)
+	} else {
+		c = exec.Command(editor, f.Name())
+	}
+
+	return tea.ExecProcess(c, func(err error) tea.Msg {
+		return editorFinishedMsg{err: err, filename: f.Name()}
+	})
+}
+
 func (m *AIMessageModel) Init() tea.Cmd {
 	return tea.Batch(
 		m.spinner.Tick,
@@ -138,6 +193,25 @@ func (m *AIMessageModel) Init() tea.Cmd {
 }
 
 func (m *AIMessageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Handle internal editor state
+	if m.state == StateEditing {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			switch msg.String() {
+			case "esc":
+				m.state = StateGenerated
+				return m, nil
+			case "ctrl+s":
+				m.commitMessage = m.textArea.Value()
+				m.state = StateGenerated
+				return m, nil
+			}
+		}
+		var cmd tea.Cmd
+		m.textArea, cmd = m.textArea.Update(msg)
+		return m, cmd
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -171,6 +245,23 @@ func (m *AIMessageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.state = StatePushing
 				m.errMsg = ""
 				return m, tea.Batch(m.spinner.Tick, runPushAsync())
+			}
+		case "e":
+			if m.state == StateGenerated {
+				if m.editorMode == "internal" {
+					m.state = StateEditing
+					m.textArea.SetValue(m.commitMessage)
+					m.textArea.Focus()
+					return m, textarea.Blink
+				} else {
+					return m, openEditor(m.commitMessage)
+				}
+			}
+		case "r":
+			if m.state == StateGenerated {
+				m.state = StateGenerating
+				m.errMsg = ""
+				return m, tea.Batch(m.spinner.Tick, runAIAsync(m.ctx, m.provider, m.files))
 			}
 		}
 	case spinner.TickMsg:
@@ -218,6 +309,24 @@ func (m *AIMessageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.errMsg = msg.err.Error()
 			return m, nil
 		}
+	case editorFinishedMsg:
+		if msg.err != nil {
+			m.state = StateError
+			m.errMsg = msg.err.Error()
+			return m, nil
+		}
+
+		content, err := os.ReadFile(msg.filename)
+		os.Remove(msg.filename) // Clean up
+
+		if err != nil {
+			m.state = StateError
+			m.errMsg = err.Error()
+			return m, nil
+		}
+
+		m.commitMessage = strings.TrimSpace(string(content))
+		return m, nil
 	}
 
 	return m, nil
@@ -266,10 +375,7 @@ func (m *AIMessageModel) View() string {
 		header := shared.HeaderStyle.Render("AI commit message suggestion:")
 		b.WriteString("\n" + header + "\n")
 		b.WriteString(m.commitMessage + "\n")
-		// TODO: Implement edit and regenerate functionality
-		// For now, we just show commit and cancel options
-		// b.WriteString("\n[e] Edit   [r] Regenerate   [c] Commit   [x] Cancel\n")
-		b.WriteString("\n[c] Commit   [x] Cancel\n")
+		b.WriteString("\n[e] Edit   [r] Regenerate   [c] Commit   [x] Cancel\n")
 		return b.String()
 	case StateSecurityWarning:
 		var b strings.Builder
@@ -279,6 +385,13 @@ func (m *AIMessageModel) View() string {
 		b.WriteString("\nDo you wish to continue?\n")
 		b.WriteString("\n[Y] yes   [n] no\n")
 		return b.String()
+	case StateEditing:
+		return fmt.Sprintf(
+			"\n%s\n\n%s\n\n%s",
+			shared.HeaderStyle.Render("Edit commit message:"),
+			m.textArea.View(),
+			"(ctrl+s to save, esc to cancel)",
+		)
 	default:
 		// fallback - shouldn't happen
 		return "\n" + shared.HeaderStyle.Render("Unknown state") + "\n"

--- a/internal/tui/suggest/ai_message.go
+++ b/internal/tui/suggest/ai_message.go
@@ -150,7 +150,7 @@ func runPushAsync() tea.Cmd {
 	}
 }
 
-func openEditor(content string) tea.Cmd {
+func openEditor(content string, editorCmd string) tea.Cmd {
 	f, err := os.CreateTemp("", "gitai-commit-msg-*.txt")
 	if err != nil {
 		return func() tea.Msg { return aiErrorMsg{err: err} }
@@ -163,12 +163,15 @@ func openEditor(content string) tea.Cmd {
 	}
 	f.Close()
 
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = os.Getenv("VISUAL")
-	}
-	if editor == "" {
-		editor = "vim"
+	editor := editorCmd
+	if editor == "" || editor == "system" {
+		editor = os.Getenv("EDITOR")
+		if editor == "" {
+			editor = os.Getenv("VISUAL")
+		}
+		if editor == "" {
+			editor = "vim"
+		}
 	}
 
 	parts := strings.Fields(editor)
@@ -248,13 +251,13 @@ func (m *AIMessageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "e":
 			if m.state == StateGenerated {
-				if m.editorMode == "internal" {
+				if m.editorMode == "builtin" {
 					m.state = StateEditing
 					m.textArea.SetValue(m.commitMessage)
 					m.textArea.Focus()
 					return m, textarea.Blink
 				} else {
-					return m, openEditor(m.commitMessage)
+					return m, openEditor(m.commitMessage, m.editorMode)
 				}
 			}
 		case "r":

--- a/internal/tui/suggest/suggest_flow.go
+++ b/internal/tui/suggest/suggest_flow.go
@@ -8,7 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func RunSuggestFlow(ctx context.Context, provider ai.Provider) {
+func RunSuggestFlow(ctx context.Context, provider ai.Provider, editorMode string) {
 	files, err := git.GetChangedFiles()
 	if err != nil {
 		panic(err)
@@ -41,7 +41,7 @@ func RunSuggestFlow(ctx context.Context, provider ai.Provider) {
 		return
 	}
 
-	aiModel := NewAIMessageModel(ctx, selectedFiles, provider)
+	aiModel := NewAIMessageModel(ctx, selectedFiles, provider, editorMode)
 	aiModelProgram := tea.NewProgram(&aiModel, tea.WithContext(ctx))
 
 	_, err = aiModelProgram.Run()


### PR DESCRIPTION
To be merged after #25 

- Introduce `command` variable to allow mocking `exec.Command` calls for testing.
- Update `git` package functions to utilize the mockable `command` variable.
- Add comprehensive unit tests for `GetStatusForFiles`, `GetChangedFiles`, `GetChangesForFiles`, `Commit`, and `Push`.
- Add unit tests for `GetGitRoot`.
- Refactor `GetStatusForFiles` by introducing `filterStatusLines` for clearer logic.
- Remove unused `GetDiff` and `GetStatus` functions.

close #20 


review @huseynovvusal 