### PR TITLE
feat(tui/suggest): Display pull request links after successful push

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -148,12 +148,13 @@ func Commit(files []string, message string) error {
 }
 
 // Push pushes the current branch to the remote repository.
-// This simplified version returns Git's helpful error messages directly.
-func Push() error {
+// It returns the command output and any error encountered.
+func Push() (string, error) {
 	cmd := command("git", "push")
 	out, err := cmd.CombinedOutput()
+	output := string(out)
 	if err != nil {
-		return fmt.Errorf("git push failed: %s", string(out))
+		return output, fmt.Errorf("git push failed: %s", output)
 	}
-	return nil
+	return output, nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -372,21 +372,20 @@ func TestPush(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
-			defer func() { command = exec.Command }()
-
-			err := Push()
-
-			if err != nil && tc.expectedErr == "" {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if err == nil && tc.expectedErr != "" {
-				t.Fatalf("expected error but got none")
-			}
-			if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
-				t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
-			}
-		})
-	}
+		        t.Run(tc.name, func(t *testing.T) {
+		            command = newMockExecCommand(t, tc.expectedCmdArgs, tc.stdout, tc.stderr, tc.exitCode)
+		            defer func() { command = exec.Command }()
+		
+		            _, err := Push()
+		
+		            if err != nil && tc.expectedErr == "" {
+		                t.Fatalf("unexpected error: %v", err)
+		            }
+		            if err == nil && tc.expectedErr != "" {
+		                t.Fatalf("expected error but got none")
+		            }
+		            if err != nil && !strings.Contains(err.Error(), tc.expectedErr) {
+		                t.Fatalf("expected error '%s', got '%s'", tc.expectedErr, err.Error())
+		            }
+		        })	}
 }

--- a/internal/tui/suggest/ai_message.go
+++ b/internal/tui/suggest/ai_message.go
@@ -30,7 +30,8 @@ type commitResultMsg struct {
 }
 
 type pushResultMsg struct {
-	err error
+	err    error
+	output string
 }
 
 type commitSecurityWarningMsg struct {
@@ -71,6 +72,11 @@ type AIMessageModel struct {
 	ctx           context.Context
 	editorMode    string
 	textArea      textarea.Model
+<<<<<<< Updated upstream
+=======
+	hint          string
+	pushOutput    string
+>>>>>>> Stashed changes
 }
 
 func NewAIMessageModel(ctx context.Context, files []string, provider ai.Provider, editorMode string) AIMessageModel {
@@ -145,8 +151,8 @@ func runCommitAsync(files []string, message string) tea.Cmd {
 
 func runPushAsync() tea.Cmd {
 	return func() tea.Msg {
-		err := git.Push()
-		return pushResultMsg{err: err}
+		out, err := git.Push()
+		return pushResultMsg{err: err, output: out}
 	}
 }
 
@@ -301,6 +307,7 @@ func (m *AIMessageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// push succeeded; transition to pushed state
 		m.state = StatePushed
+		m.pushOutput = msg.output
 		m.errMsg = ""
 		return m, tea.Quit
 	case commitSecurityWarningMsg:

--- a/internal/tui/suggest/suggest_flow.go
+++ b/internal/tui/suggest/suggest_flow.go
@@ -2,8 +2,10 @@ package suggest
 
 import (
 	"context"
+	"fmt"
 	"huseynovvusal/gitai/internal/ai"
 	"huseynovvusal/gitai/internal/git"
+	"regexp"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -44,9 +46,21 @@ func RunSuggestFlow(ctx context.Context, provider ai.Provider, editorMode string
 	aiModel := NewAIMessageModel(ctx, selectedFiles, provider, editorMode)
 	aiModelProgram := tea.NewProgram(&aiModel, tea.WithContext(ctx))
 
-	_, err = aiModelProgram.Run()
+	finalModel, err := aiModelProgram.Run()
 	if err != nil {
 		panic(err)
 	}
 
+	if m, ok := finalModel.(*AIMessageModel); ok && m.state == StatePushed {
+		re := regexp.MustCompile(`remote:\s*(https?://\S+)`)
+		matches := re.FindAllStringSubmatch(m.pushOutput, -1)
+		if len(matches) > 0 {
+			fmt.Println()
+		}
+		for _, match := range matches {
+			if len(match) > 1 {
+				fmt.Printf("Create a Pull Request: %s\n", match[1])
+			}
+		}
+	}
 }


### PR DESCRIPTION
- `git.Push` function now returns the command output in addition to any error.
- `pushResultMsg` and `AIMessageModel` updated to store the `git push` command's output.
- Extract remote repository URLs from the `git push` output and suggest pull request creation links to the user.